### PR TITLE
FIX: Plugins weren't loaded when running via bundled stree

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,7 +95,7 @@ export async function activate(context: ExtensionContext) {
 
     try {
       await promiseExec("bundle show syntax_tree", { cwd });
-      run = { command: "bundle", args: ["exec", "stree", "lsp"], options: { cwd } };
+      run = { command: "bundle", args: ["exec", "stree"].concat(args), options: { cwd } };
       where = 'bundled';
     } catch {
       // No-op (just keep using the global stree)


### PR DESCRIPTION
When running the extension and `stree` from the bundle the plugin list wasn't loaded.