### PR TITLE
Fix packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
   },
   "scripts": {
     "compile": "tsc -p ./",
-    "package": "vsce package --yarn --githubBranch main",
-    "publish": "vsce publish --yarn --githubBranch main",
+    "package": "vsce package --no-yarn --githubBranch main",
+    "publish": "vsce publish --no-yarn --githubBranch main",
     "test": "node ./out/test/runTest.js",
     "vscode:prepublish": "yarn compile",
     "watch": "tsc --watch -p ./"


### PR DESCRIPTION
Fixes #29.

The `--yarn` option flatten dependencies, which is not possible at the moment since

- `vscode-languageclient` needs semver > 7
- `vsce` needs `parse-semver` 1.1.1  which needs semver 5.1.0 and < 7

This is know problem with vsce packaging, see https://github.com/microsoft/vscode-vsce/issues/432