### PR TITLE
Adds support for ERB-files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "vscode": "^1.68.0"
   },
   "activationEvents": [
+    "onLanguage:erb",
     "onLanguage:haml",
     "onLanguage:ruby",
     "workspaceContains:Gemfile.lock",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,6 +196,7 @@ export async function activate(context: ExtensionContext) {
     // responsible for the communication and management of the Ruby subprocess.
     languageClient = new LanguageClient("Syntax Tree", { run, debug: run }, {
       documentSelector: [
+        { scheme: "file", language: "erb" },
         { scheme: "file", language: "haml" },
         { scheme: "file", language: "ruby" },
         { scheme: "file", pattern: "**/Gemfile" },


### PR DESCRIPTION
Hello!

I have written a SyntaxTree-plugin for ERB-files and would like support for it in the language server.

https://github.com/davidwessman/syntax_tree-erb

Would it make sense to add it like this even for an unofficial plugin?
